### PR TITLE
Partial event handling

### DIFF
--- a/group.go
+++ b/group.go
@@ -12,7 +12,7 @@ import (
 
 type StateHandler interface {
 	// returns
-	Plan(events []Event, user interface{}) (interface{}, error)
+	Plan(events []Event, user interface{}) (interface{}, uint64, error)
 }
 
 // StateGroup manages a group of state machines sharing the same logic

--- a/machine_test.go
+++ b/machine_test.go
@@ -3,6 +3,7 @@ package statemachine
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log"
@@ -19,11 +20,11 @@ type testHandler struct {
 	done    chan struct{}
 }
 
-func (t *testHandler) Plan(events []Event, state interface{}) (interface{}, error) {
+func (t *testHandler) Plan(events []Event, state interface{}) (interface{}, uint64, error) {
 	return t.plan(events, state.(*TestState))
 }
 
-func (t *testHandler) plan(events []Event, state *TestState) (func(Context, TestState) error, error) {
+func (t *testHandler) plan(events []Event, state *TestState) (func(Context, TestState) error, uint64, error) {
 	for _, event := range events {
 		e := event.User.(*TestEvent)
 		switch e.A {
@@ -38,9 +39,9 @@ func (t *testHandler) plan(events []Event, state *TestState) (func(Context, Test
 
 	switch state.A {
 	case 1:
-		return t.step0, nil
+		return t.step0, uint64(len(events)), nil
 	case 2:
-		return t.step1, nil
+		return t.step1, uint64(len(events)), nil
 	default:
 		t.t.Fatal(state.A)
 	}
@@ -102,4 +103,136 @@ func TestPersist(t *testing.T) {
 	}
 }
 
+func TestPartialHandling(t *testing.T) {
+	ds := datastore.NewMapDatastore()
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	th := &testHandlerPartial{
+		t:        t,
+		done:     make(chan struct{}),
+		proceed:  make(chan struct{}),
+		proceed2: make(chan struct{}),
+		started:  make(chan struct{}),
+		midpoint: make(chan struct{}),
+	}
+	smm := New(ds, th, TestState{})
+
+	checkState := func(state uint64) {
+		var testState TestState
+		stored := smm.Get(uint64(2))
+		err := stored.Get(&testState)
+		assert.NilError(t, err)
+		assert.Equal(t, testState.A, state)
+	}
+
+	// send first event
+	if err := smm.Send(uint64(2), &TestEvent{A: "start"}); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	// wait for it to process
+	select {
+	case <-ctx.Done():
+		t.Fatal("Did not process first event")
+	case <-th.started:
+	}
+
+	// verify in first state
+	checkState(1)
+
+	// send two events with the first handler still running
+	if err := smm.Send(uint64(2), &TestEvent{A: "b"}); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if err := smm.Send(uint64(2), &TestEvent{A: "c"}); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	// complete first handler
+	close(th.proceed)
+
+	// wait for second event to process
+	select {
+	case <-ctx.Done():
+		t.Fatal("Did not process second event")
+	case <-th.midpoint:
+	}
+
+	// verify in second state
+	checkState(2)
+
+	// complete second handler
+	close(th.proceed2)
+
+	// wait for final event for to process -- assuming partial processing works right
+	// plan should get called a third time and processed
+	select {
+	case <-ctx.Done():
+		t.Fatal("Did not process third event")
+	case <-th.done:
+	}
+
+	// verify in third state
+	checkState(3)
+
+}
+
+type testHandlerPartial struct {
+	t        *testing.T
+	started  chan struct{}
+	proceed  chan struct{}
+	midpoint chan struct{}
+	proceed2 chan struct{}
+	done     chan struct{}
+}
+
+func (t *testHandlerPartial) Plan(events []Event, state interface{}) (interface{}, uint64, error) {
+	return t.plan(events, state.(*TestState))
+}
+
+func (t *testHandlerPartial) plan(events []Event, state *TestState) (func(Context, TestState) error, uint64, error) {
+	event := events[0]
+	e := event.User.(*TestEvent)
+	switch e.A {
+	case "start":
+		state.A = 1
+	case "b":
+		state.A = 2
+	case "c":
+		state.A = 3
+	}
+
+	switch state.A {
+	case 1:
+		return t.step0, 1, nil
+	case 2:
+		return t.step1, 1, nil
+	case 3:
+		return t.step2, 1, nil
+	default:
+		t.t.Fatal(state.A)
+	}
+	panic("how?")
+}
+
+func (t *testHandlerPartial) step0(ctx Context, st TestState) error {
+	close(t.started)
+	<-t.proceed
+	return nil
+}
+
+func (t *testHandlerPartial) step1(ctx Context, st TestState) error {
+	close(t.midpoint)
+	<-t.proceed2
+	return nil
+}
+
+func (t *testHandlerPartial) step2(ctx Context, st TestState) error {
+	close(t.done)
+	return nil
+}
+
 var _ StateHandler = &testHandler{}
+var _ StateHandler = &testHandlerPartial{}


### PR DESCRIPTION
# Goals

When a statemachine receives many events at once, it may want to defer processing of some of them, and move immediately to a state handler to decide what to do with the new state

# Implementation

- Add a parameter to the planning function return that describes how many events where processes (from 0 to len(events))
- When the value is less than len(events), keep unprocessed events in the queue, only remove those that are processed
