### PR TITLE
fix(statemachine): fix nil state handler breaks processing

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -79,6 +79,7 @@ func (fsm *StateMachine) run() {
 				pendingEvents = nil
 			}
 			if nextStep == nil {
+				atomic.StoreInt32(&fsm.busy, 0)
 				continue
 			}
 


### PR DESCRIPTION
The code is setup to ignore a "nextStep" of nil, but as it's written currently, it will block event
processing for every cause the mutex is never unlocked