### PR TITLE
Run event callbacks concurrently

### DIFF
--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -90,7 +90,7 @@ func (d fsmHandler) Plan(events []statemachine.Event, user interface{}) (interfa
 	}
 	currentState := userValue.Elem().FieldByName(string(d.stateKeyField)).Interface()
 	if d.notifier != nil {
-		d.notifier(eventName, userValue.Elem().Interface())
+		go d.notifier(eventName, userValue.Elem().Interface())
 	}
 	_, final := d.finalityStates[currentState]
 	if final {


### PR DESCRIPTION
## Summary
Running event notification callbacks synchronously can cause a deadlock in the main event processing loop, so pushing this into a goroutine.

