### PR TITLE
Fix/in order notifications cleanup

### DIFF
--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -119,9 +119,9 @@ func (d fsmHandler) reachedFinalityState(user interface{}) bool {
 	return final
 }
 
-// initNotifier will start up a goroutine which processes the notification queue
+// Init will start up a goroutine which processes the notification queue
 // in order
-func (d fsmHandler) initNotifier(closing <-chan struct{}) {
+func (d fsmHandler) Init(closing <-chan struct{}) {
 	if d.notifier != nil {
 		queue := make([]notification, 0, NotificationQueueSize)
 		toProcess := make(chan notification)

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -73,7 +73,9 @@ func NewFSMHandler(parameters Parameters) (statemachine.StateHandler, error) {
 		d.finalityStates[finalityState] = struct{}{}
 	}
 
-	d.initNotifier()
+	if d.notifier != nil {
+		d.notifications = make(chan notification)
+	}
 
 	return d, nil
 }
@@ -119,13 +121,42 @@ func (d fsmHandler) reachedFinalityState(user interface{}) bool {
 
 // initNotifier will start up a goroutine which processes the notification queue
 // in order
-func (d *fsmHandler) initNotifier() {
+func (d fsmHandler) initNotifier(closing <-chan struct{}) {
 	if d.notifier != nil {
-		d.notifications = make(chan notification, NotificationQueueSize)
-
+		queue := make([]notification, 0, NotificationQueueSize)
+		toProcess := make(chan notification)
 		go func() {
-			for n := range d.notifications {
-				d.notifier(n.eventName, n.state)
+			for {
+				select {
+				case n := <-toProcess:
+					d.notifier(n.eventName, n.state)
+				case <-closing:
+					return
+				}
+			}
+		}()
+		go func() {
+			outgoing := func() chan<- notification {
+				if len(queue) == 0 {
+					return nil
+				}
+				return toProcess
+			}
+			nextNofication := func() notification {
+				if len(queue) == 0 {
+					return notification{}
+				}
+				return queue[0]
+			}
+			for {
+				select {
+				case n := <-d.notifications:
+					queue = append(queue, n)
+				case outgoing() <- nextNofication():
+					queue = queue[1:]
+				case <-closing:
+					return
+				}
 			}
 		}()
 	}

--- a/fsm/fsm_group.go
+++ b/fsm/fsm_group.go
@@ -2,6 +2,7 @@ package fsm
 
 import (
 	"context"
+	"sync"
 
 	"github.com/filecoin-project/go-statemachine"
 	"github.com/ipfs/go-datastore"
@@ -11,7 +12,9 @@ import (
 // StateGroup manages a group of states with finite state machine logic
 type stateGroup struct {
 	*statemachine.StateGroup
-	d fsmHandler
+	d            fsmHandler
+	closing      chan struct{}
+	initNotifier sync.Once
 }
 
 // New generates a new state group that operates like a finite state machine,
@@ -24,13 +27,18 @@ func New(ds datastore.Datastore, parameters Parameters) (Group, error) {
 		return nil, err
 	}
 	d := handler.(fsmHandler)
-	return &stateGroup{StateGroup: statemachine.New(ds, handler, parameters.StateType), d: d}, nil
+	return &stateGroup{StateGroup: statemachine.New(ds, handler, parameters.StateType), d: d, closing: make(chan struct{})}, nil
+}
+
+func (s *stateGroup) init() {
+	s.d.initNotifier(s.closing)
 }
 
 // Send sends the given event name and parameters to the state specified by id
 // it will error if there are underlying state store errors or if the parameters
 // do not match what is expected for the event name
 func (s *stateGroup) Send(id interface{}, name EventName, args ...interface{}) (err error) {
+	s.initNotifier.Do(s.init)
 	evt, err := s.d.eventProcessor.Generate(context.TODO(), name, nil, args...)
 	if err != nil {
 		return err
@@ -47,6 +55,7 @@ func (s *stateGroup) IsTerminated(out StateType) bool {
 // it will error if there are underlying state store errors or if the parameters
 // do not match what is expected for the event name
 func (s *stateGroup) SendSync(ctx context.Context, id interface{}, name EventName, args ...interface{}) (err error) {
+	s.initNotifier.Do(s.init)
 	returnChannel := make(chan error, 1)
 	evt, err := s.d.eventProcessor.Generate(ctx, name, returnChannel, args...)
 	if err != nil {
@@ -64,4 +73,13 @@ func (s *stateGroup) SendSync(ctx context.Context, id interface{}, name EventNam
 	case err := <-returnChannel:
 		return err
 	}
+}
+
+func (s *stateGroup) Begin(id interface{}, userState interface{}) error {
+	s.initNotifier.Do(s.init)
+	return s.StateGroup.Begin(id, userState)
+}
+func (s *stateGroup) Stop(ctx context.Context) error {
+	close(s.closing)
+	return s.StateGroup.Stop(ctx)
 }

--- a/fsm/fsm_group.go
+++ b/fsm/fsm_group.go
@@ -2,7 +2,6 @@ package fsm
 
 import (
 	"context"
-	"sync"
 
 	"github.com/filecoin-project/go-statemachine"
 	"github.com/ipfs/go-datastore"
@@ -12,9 +11,7 @@ import (
 // StateGroup manages a group of states with finite state machine logic
 type stateGroup struct {
 	*statemachine.StateGroup
-	d            fsmHandler
-	closing      chan struct{}
-	initNotifier sync.Once
+	d fsmHandler
 }
 
 // New generates a new state group that operates like a finite state machine,
@@ -27,18 +24,13 @@ func New(ds datastore.Datastore, parameters Parameters) (Group, error) {
 		return nil, err
 	}
 	d := handler.(fsmHandler)
-	return &stateGroup{StateGroup: statemachine.New(ds, handler, parameters.StateType), d: d, closing: make(chan struct{})}, nil
-}
-
-func (s *stateGroup) init() {
-	s.d.initNotifier(s.closing)
+	return &stateGroup{StateGroup: statemachine.New(ds, handler, parameters.StateType), d: d}, nil
 }
 
 // Send sends the given event name and parameters to the state specified by id
 // it will error if there are underlying state store errors or if the parameters
 // do not match what is expected for the event name
 func (s *stateGroup) Send(id interface{}, name EventName, args ...interface{}) (err error) {
-	s.initNotifier.Do(s.init)
 	evt, err := s.d.eventProcessor.Generate(context.TODO(), name, nil, args...)
 	if err != nil {
 		return err
@@ -55,7 +47,6 @@ func (s *stateGroup) IsTerminated(out StateType) bool {
 // it will error if there are underlying state store errors or if the parameters
 // do not match what is expected for the event name
 func (s *stateGroup) SendSync(ctx context.Context, id interface{}, name EventName, args ...interface{}) (err error) {
-	s.initNotifier.Do(s.init)
 	returnChannel := make(chan error, 1)
 	evt, err := s.d.eventProcessor.Generate(ctx, name, returnChannel, args...)
 	if err != nil {
@@ -73,13 +64,4 @@ func (s *stateGroup) SendSync(ctx context.Context, id interface{}, name EventNam
 	case err := <-returnChannel:
 		return err
 	}
-}
-
-func (s *stateGroup) Begin(id interface{}, userState interface{}) error {
-	s.initNotifier.Do(s.init)
-	return s.StateGroup.Begin(id, userState)
-}
-func (s *stateGroup) Stop(ctx context.Context) error {
-	close(s.closing)
-	return s.StateGroup.Stop(ctx)
 }

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -488,9 +488,11 @@ func TestSerialNotification(t *testing.T) {
 	var notifications []string
 
 	wg := sync.WaitGroup{}
+	handleNotifications := make(chan struct{})
 	wg.Add(len(events))
 
 	var notifier fsm.Notifier = func(eventName fsm.EventName, state fsm.StateType) {
+		<-handleNotifications
 		notifications = append(notifications, eventName.(string))
 		wg.Done()
 	}
@@ -512,7 +514,7 @@ func TestSerialNotification(t *testing.T) {
 		err = smm.Send(uint64(2), eventName)
 		require.NoError(t, err)
 	}
-
+	close(handleNotifications)
 	wg.Wait()
 
 	// Expect that notifications happened in the order that the events happened

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ipfs/go-datastore"
+	dss "github.com/ipfs/go-datastore/sync"
 	logging "github.com/ipfs/go-log"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
@@ -57,7 +58,7 @@ var stateEntryFuncs = fsm.StateEntryFuncs{
 }
 
 func TestTypeCheckingOnSetup(t *testing.T) {
-	ds := datastore.NewMapDatastore()
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
 	te := &testEnvironment{t: t, done: make(chan struct{}), proceed: make(chan struct{})}
 	t.Run("Bad state field", func(t *testing.T) {
 		smm, err := fsm.New(ds, fsm.Parameters{
@@ -350,7 +351,7 @@ func newFsm(ds datastore.Datastore, te *testEnvironment) (fsm.Group, error) {
 }
 
 func TestArgumentChecks(t *testing.T) {
-	ds := datastore.NewMapDatastore()
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
 	te := &testEnvironment{t: t, done: make(chan struct{}), proceed: make(chan struct{})}
 	smm, err := newFsm(ds, te)
 	close(te.proceed)
@@ -372,7 +373,7 @@ func TestArgumentChecks(t *testing.T) {
 
 func TestBasic(t *testing.T) {
 	for i := 0; i < 1000; i++ { // run a few times to expose any races
-		ds := datastore.NewMapDatastore()
+		ds := dss.MutexWrap(datastore.NewMapDatastore())
 
 		te := &testEnvironment{t: t, done: make(chan struct{}), proceed: make(chan struct{})}
 		close(te.proceed)
@@ -389,7 +390,7 @@ func TestBasic(t *testing.T) {
 
 func TestPersist(t *testing.T) {
 	for i := 0; i < 1000; i++ { // run a few times to expose any races
-		ds := datastore.NewMapDatastore()
+		ds := dss.MutexWrap(datastore.NewMapDatastore())
 
 		te := &testEnvironment{t: t, done: make(chan struct{}), proceed: make(chan struct{})}
 		smm, err := newFsm(ds, te)
@@ -416,7 +417,7 @@ func TestPersist(t *testing.T) {
 
 func TestSyncEventHandling(t *testing.T) {
 	ctx := context.Background()
-	ds := datastore.NewMapDatastore()
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
 
 	te := &testEnvironment{t: t, done: make(chan struct{}), proceed: make(chan struct{})}
 	smm, err := newFsm(ds, te)
@@ -448,7 +449,7 @@ func TestNotification(t *testing.T) {
 		notifications++
 	}
 
-	ds := datastore.NewMapDatastore()
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
 
 	te := &testEnvironment{t: t, done: make(chan struct{}), proceed: make(chan struct{}), universalCalls: 0}
 	close(te.proceed)
@@ -497,7 +498,7 @@ func TestSerialNotification(t *testing.T) {
 		wg.Done()
 	}
 
-	ds := datastore.NewMapDatastore()
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
 	params := fsm.Parameters{
 		Environment:     te,
 		StateType:       statemachine.TestState{},
@@ -522,7 +523,7 @@ func TestSerialNotification(t *testing.T) {
 }
 
 func TestNoChangeHandler(t *testing.T) {
-	ds := datastore.NewMapDatastore()
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
 
 	te := &testEnvironment{t: t, done: make(chan struct{}), proceed: make(chan struct{}), universalCalls: 0}
 	close(te.proceed)
@@ -541,7 +542,7 @@ func TestNoChangeHandler(t *testing.T) {
 }
 
 func TestAllStateEvent(t *testing.T) {
-	ds := datastore.NewMapDatastore()
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
 
 	te := &testEnvironment{t: t, done: make(chan struct{}), proceed: make(chan struct{}), universalCalls: 0}
 	close(te.proceed)
@@ -565,7 +566,7 @@ func TestFinalityStates(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
-	ds := datastore.NewMapDatastore()
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
 
 	te := &testEnvironment{t: t, done: make(chan struct{}), proceed: make(chan struct{})}
 	smm, err := newFsm(ds, te)

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -443,10 +444,10 @@ func TestSyncEventHandling(t *testing.T) {
 }
 
 func TestNotification(t *testing.T) {
-	notifications := 0
+	notifications := new(uint64)
 
 	var notifier fsm.Notifier = func(eventName fsm.EventName, state fsm.StateType) {
-		notifications++
+		atomic.AddUint64(notifications, 1)
 	}
 
 	ds := dss.MutexWrap(datastore.NewMapDatastore())
@@ -468,7 +469,8 @@ func TestNotification(t *testing.T) {
 	require.NoError(t, err)
 	<-te.done
 
-	require.Equal(t, notifications, 2)
+	total := atomic.LoadUint64(notifications)
+	require.Equal(t, total, uint64(2))
 }
 
 func TestSerialNotification(t *testing.T) {

--- a/machine_test.go
+++ b/machine_test.go
@@ -352,6 +352,96 @@ func (t *testHandlerNoStateCB) step1(ctx Context, st TestState) error {
 	return nil
 }
 
+type testHandlerWithGoRoutine struct {
+	t         *testing.T
+	event     chan struct{}
+	proceed   chan struct{}
+	done      chan struct{}
+	notifDone chan struct{}
+	count     uint64
+}
+
+func (t *testHandlerWithGoRoutine) Plan(events []Event, state interface{}) (interface{}, uint64, error) {
+	return t.plan(events, state.(*TestState))
+}
+
+func (t *testHandlerWithGoRoutine) Init(onClose <-chan struct{}) {
+	go func() {
+		for {
+			select {
+			case <-t.event:
+				t.count++
+			case <-onClose:
+				close(t.notifDone)
+				return
+			}
+		}
+	}()
+}
+
+func (t *testHandlerWithGoRoutine) plan(events []Event, state *TestState) (func(Context, TestState) error, uint64, error) {
+	for _, event := range events {
+		e := event.User.(*TestEvent)
+		switch e.A {
+		case "restart":
+		case "start":
+			state.A = 1
+		case "b":
+			state.A = 2
+			state.B = e.Val
+		}
+	}
+
+	t.event <- struct{}{}
+	switch state.A {
+	case 1:
+		return t.step0, uint64(len(events)), nil
+	case 2:
+		return t.step1, uint64(len(events)), nil
+	default:
+		t.t.Fatal(state.A)
+	}
+	panic("how?")
+}
+
+func (t *testHandlerWithGoRoutine) step0(ctx Context, st TestState) error {
+	ctx.Send(&TestEvent{A: "b", Val: 55}) // nolint: errcheck
+	<-t.proceed
+	return nil
+}
+
+func (t *testHandlerWithGoRoutine) step1(ctx Context, st TestState) error {
+	assert.Equal(t.t, uint64(2), st.A)
+
+	close(t.done)
+	return nil
+}
+
+func TestInit(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	for i := 0; i < 1000; i++ { // run a few times to expose any races
+		ds := datastore.NewMapDatastore()
+
+		th := &testHandlerWithGoRoutine{t: t, event: make(chan struct{}), notifDone: make(chan struct{}), done: make(chan struct{}), proceed: make(chan struct{})}
+		close(th.proceed)
+		smm := New(ds, th, TestState{})
+
+		if err := smm.Send(uint64(2), &TestEvent{A: "start"}); err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		<-th.done
+		err := smm.Stop(ctx)
+		assert.NilError(t, err)
+		<-th.notifDone
+		assert.Equal(t, uint64(2), th.count)
+	}
+
+}
+
 var _ StateHandler = &testHandler{}
 var _ StateHandler = &testHandlerPartial{}
 var _ StateHandler = &testHandlerNoStateCB{}
+var _ StateHandler = &testHandlerWithGoRoutine{}


### PR DESCRIPTION
# Goals

A bit of cleanup to solve two different issues here:
1. Make sure go routines get cleaned up
2. Make sure state machine doesn't block on channel write if notification handling is slow (this was an outstanding issue we wanted to solve) -- this uses a technique for unbounded channels described here: https://medium.com/capital-one-tech/building-an-unbounded-channel-in-go-789e175cd2cd
3. Make sure go routine doesn't start till events are sent.
4. Move support for a seperate "init" function into core state machine functionality as optional config.