### PR TITLE
feat(statemachine): add Has method

### DIFF
--- a/fsm/types.go
+++ b/fsm/types.go
@@ -112,6 +112,9 @@ type Group interface {
 	// Get gets state for a single state machine
 	Get(id interface{}) *statestore.StoredState
 
+	// Has indicates whether there is data for the given state machine
+	Has(id interface{}) (bool, error)
+
 	// List outputs states of all state machines in this group
 	// out: *[]StateT
 	List(out interface{}) error

--- a/group.go
+++ b/group.go
@@ -160,3 +160,8 @@ func (s *StateGroup) List(out interface{}) error {
 func (s *StateGroup) Get(id interface{}) *statestore.StoredState {
 	return s.sts.Get(id)
 }
+
+// Has indicates whether there is data for the given state machine
+func (s *StateGroup) Has(id interface{}) (bool, error) {
+	return s.sts.Has(id)
+}


### PR DESCRIPTION
# Goals

Since Send automatically creates a new zero value statemachine, in the case where you don't want to actually initiatialize a statemachine unless it already exists, you have to call Get, which is a potentially more expensive operation.

# Implementation

Just add a has method -- pipe to statestore has