### PR TITLE
GetSync method

### DIFF
--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -84,6 +84,9 @@ func (d fsmHandler) Plan(events []statemachine.Event, user interface{}) (interfa
 		return nil, uint64(len(events)), statemachine.ErrTerminated
 	}
 	eventName, err := d.eventProcessor.Apply(events[0], user)
+	if _, ok := eventName.(nilEvent); ok {
+		return nil, 1, nil
+	}
 	if err != nil {
 		log.Errorf("Executing event planner failed: %+v", err)
 		return nil, 1, nil

--- a/fsm/fsm_group.go
+++ b/fsm/fsm_group.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/filecoin-project/go-statemachine"
 	"github.com/ipfs/go-datastore"
+	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
 )
 
@@ -41,6 +42,16 @@ func (s *stateGroup) Send(id interface{}, name EventName, args ...interface{}) (
 // IsTerminated returns true if a StateType is in a FinalityState
 func (s *stateGroup) IsTerminated(out StateType) bool {
 	return s.d.reachedFinalityState(out)
+}
+
+// GetSync will make sure all events present at the time of the call are processed before
+// returning a value, which is read into out
+func (s *stateGroup) GetSync(ctx context.Context, id interface{}, out cbg.CBORUnmarshaler) error {
+	err := s.SendSync(ctx, id, nilEvent{})
+	if err != nil {
+		return err
+	}
+	return s.Get(id).Get(out)
 }
 
 // SendSync sends the given event name and parameters to the state specified by id

--- a/fsm/fsm_group.go
+++ b/fsm/fsm_group.go
@@ -48,7 +48,7 @@ func (s *stateGroup) IsTerminated(out StateType) bool {
 // returning a value, which is read into out
 func (s *stateGroup) GetSync(ctx context.Context, id interface{}, out cbg.CBORUnmarshaler) error {
 	err := s.SendSync(ctx, id, nilEvent{})
-	if err != nil {
+	if err != nil && err != statemachine.ErrTerminated {
 		return err
 	}
 	return s.Get(id).Get(out)

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -446,6 +446,35 @@ func TestSyncEventHandling(t *testing.T) {
 
 }
 
+func TestGetSync(t *testing.T) {
+	ctx := context.Background()
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
+
+	te := &testEnvironment{t: t, done: make(chan struct{}), proceed: make(chan struct{})}
+
+	// setup with no state entry funcs, so that B just sets the value
+	params := fsm.Parameters{
+		Environment:     te,
+		StateType:       statemachine.TestState{},
+		StateKeyField:   "A",
+		Events:          events,
+		StateEntryFuncs: fsm.StateEntryFuncs{},
+		FinalityStates:  []fsm.StateKey{uint64(3)},
+		Notifier:        nil,
+	}
+	smm, err := fsm.New(ds, params)
+	require.NoError(t, err)
+
+	smm.Send(uint64(2), "start")
+	for i := 0; i < 100; i++ {
+		smm.Send(uint64(2), "restart")
+		smm.Send(uint64(2), "b", uint64(i))
+		var ts statemachine.TestState
+		smm.GetSync(ctx, uint64(2), &ts)
+		require.Equal(t, ts.B, uint64(i))
+	}
+}
+
 func TestNotification(t *testing.T) {
 	notifications := new(uint64)
 

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -465,12 +465,19 @@ func TestGetSync(t *testing.T) {
 	smm, err := fsm.New(ds, params)
 	require.NoError(t, err)
 
-	smm.Send(uint64(2), "start")
+	err = smm.Send(uint64(2), "start")
+	require.NoError(t, err)
 	for i := 0; i < 100; i++ {
-		smm.Send(uint64(2), "restart")
-		smm.Send(uint64(2), "b", uint64(i))
+		err = smm.Send(uint64(2), "restart")
+		require.NoError(t, err)
+
+		err = smm.Send(uint64(2), "b", uint64(i))
+		require.NoError(t, err)
+
 		var ts statemachine.TestState
-		smm.GetSync(ctx, uint64(2), &ts)
+		err = smm.GetSync(ctx, uint64(2), &ts)
+		require.NoError(t, err)
+
 		require.Equal(t, ts.B, uint64(i))
 	}
 }

--- a/fsm/types.go
+++ b/fsm/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/filecoin-project/go-statestore"
+	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
 // EventName is the name of an event
@@ -111,6 +112,10 @@ type Group interface {
 
 	// Get gets state for a single state machine
 	Get(id interface{}) *statestore.StoredState
+
+	// GetSync will make sure all events present at the time of the call are processed before
+	// returning a value, which is read into out
+	GetSync(ctx context.Context, id interface{}, value cbg.CBORUnmarshaler) error
 
 	// Has indicates whether there is data for the given state machine
 	Has(id interface{}) (bool, error)


### PR DESCRIPTION
# Goals

Often we want to dispatch events and then read the result. However, currently, Get reads from the datastore immediately, while the events may still not have been processed in thread. GetSync allows you to get the value with a guarantee that any events you've already dispatched will be processed before your value is read.

# Implementation

- GetSync works by using the existing SendSync functionality and dispatching a hidden event on call. Essentially, send a hidden event, wait for it to complete (since events are processed in order, this means any other events will already be processed), then read the value from the datastore