### PR TITLE
Just Record Events

### DIFF
--- a/fsm/eventbuilder.go
+++ b/fsm/eventbuilder.go
@@ -2,6 +2,8 @@ package fsm
 
 import "golang.org/x/xerrors"
 
+type recordEvent struct{}
+
 type transitionToBuilder struct {
 	name             EventName
 	action           ActionFunc
@@ -23,6 +25,15 @@ func (t transitionToBuilder) ToNoChange() EventBuilder {
 	transitions := t.transitionsSoFar
 	for _, from := range t.nextFrom {
 		transitions[from] = nil
+	}
+	return eventBuilder{t.name, t.action, transitions}
+}
+
+// ToJustRecord means a transition ends in the same state it started in (and DOES NOT retrigger state cb)
+func (t transitionToBuilder) ToJustRecord() EventBuilder {
+	transitions := t.transitionsSoFar
+	for _, from := range t.nextFrom {
+		transitions[from] = recordEvent{}
 	}
 	return eventBuilder{t.name, t.action, transitions}
 }
@@ -121,6 +132,11 @@ func (e errBuilder) To(_ StateKey) EventBuilder {
 
 // ToNoChange passes on the error
 func (e errBuilder) ToNoChange() EventBuilder {
+	return e
+}
+
+// ToJustRecord passes on the error
+func (e errBuilder) ToJustRecord() EventBuilder {
 	return e
 }
 

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -87,7 +87,8 @@ func (d fsmHandler) Plan(events []statemachine.Event, user interface{}) (interfa
 	if _, ok := eventName.(nilEvent); ok {
 		return nil, 1, nil
 	}
-	if err != nil {
+	_, justRecord := err.(justRecordError)
+	if err != nil && !justRecord {
 		log.Errorf("Executing event planner failed: %+v", err)
 		return nil, 1, nil
 	}
@@ -99,6 +100,9 @@ func (d fsmHandler) Plan(events []statemachine.Event, user interface{}) (interfa
 	if final {
 		d.eventProcessor.ClearEvents(events[1:], statemachine.ErrTerminated)
 		return nil, uint64(len(events)), statemachine.ErrTerminated
+	}
+	if justRecord {
+		return d.handler(nil), 1, nil
 	}
 	return d.handler(d.stateEntryFuncs[currentState]), 1, nil
 }

--- a/fsm/fsm_group.go
+++ b/fsm/fsm_group.go
@@ -73,6 +73,10 @@ func (s *stateGroup) SendSync(ctx context.Context, id interface{}, name EventNam
 	case <-ctx.Done():
 		return xerrors.New("Context cancelled")
 	case err := <-returnChannel:
+		_, justRecord := err.(justRecordError)
+		if justRecord {
+			return nil
+		}
 		return err
 	}
 }

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -604,6 +604,7 @@ func TestJustRecordHandler(t *testing.T) {
 
 	var ts statemachine.TestState
 	err = smm.GetSync(context.Background(), uint64(2), &ts)
+	require.NoError(t, err)
 	require.Equal(t, uint64(1000000), ts.B)
 }
 

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -39,6 +39,10 @@ var events = fsm.Events{
 		},
 	),
 	fsm.Event("resume").FromMany(uint64(1), uint64(2)).ToNoChange(),
+	fsm.Event("justrecord").FromMany(uint64(2)).ToJustRecord().Action(func(state *statemachine.TestState) error {
+		state.B = uint64(1000000)
+		return nil
+	}),
 	fsm.Event("any").FromAny().To(uint64(1)),
 	fsm.Event("finish").FromAny().To(uint64(3)),
 }
@@ -580,6 +584,27 @@ func TestNoChangeHandler(t *testing.T) {
 	err = smm.Send(uint64(2), "resume")
 	require.NoError(t, err)
 	<-te.done
+}
+
+func TestJustRecordHandler(t *testing.T) {
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
+
+	te := &testEnvironment{t: t, done: make(chan struct{}), proceed: make(chan struct{}), universalCalls: 0}
+	close(te.proceed)
+	smm, err := newFsm(ds, te)
+	require.NoError(t, err)
+
+	err = smm.Send(uint64(2), "start")
+	require.NoError(t, err)
+	<-te.done
+
+	// call just record to change value but should not reclose done channel
+	err = smm.Send(uint64(2), "justrecord")
+	require.NoError(t, err)
+
+	var ts statemachine.TestState
+	err = smm.GetSync(context.Background(), uint64(2), &ts)
+	require.Equal(t, uint64(1000000), ts.B)
 }
 
 func TestAllStateEvent(t *testing.T) {

--- a/fsm/types.go
+++ b/fsm/types.go
@@ -54,6 +54,8 @@ type TransitionToBuilder interface {
 	To(StateKey) EventBuilder
 	// ToNoChange means a transition ends in the same state it started in (just retriggers state cb)
 	ToNoChange() EventBuilder
+	// ToJustRecord means a transition ends in the same state it started in (and DOES NOT retrigger state cb)
+	ToJustRecord() EventBuilder
 }
 
 // EventBuilder is an interface for describing events in an fsm and

--- a/fsm/umlgenerator.go
+++ b/fsm/umlgenerator.go
@@ -178,16 +178,19 @@ func generateFromAnyEventsDeclaration(w io.Writer, anyEvents []anyEventDecl, sta
 
 func generateJustRecordEventsDeclarations(w io.Writer, justRecordEvents map[StateKey][]EventName, stateNameMap reflect.Value, eventNameMap reflect.Value) error {
 	for state, events := range justRecordEvents {
-		if _, err := fmt.Fprintf(w, "\tnote right of %v\n\t\tThe following events only record in this state.\n\n", state); err != nil {
+		if _, err := fmt.Fprintf(w, "\n\tnote right of %v : The following events only record in this state.", state); err != nil {
 			return err
 		}
 		for _, event := range events {
+			if _, err := fmt.Fprintf(w, "<br>"); err != nil {
+				return err
+			}
 			eventName := eventNameMap.MapIndex(reflect.ValueOf(event))
-			if _, err := fmt.Fprintf(w, "\t\t%s\n", eventName); err != nil {
+			if _, err := fmt.Fprintf(w, "%s", eventName); err != nil {
 				return err
 			}
 		}
-		if _, err := fmt.Fprintf(w, "\tend note\n\n"); err != nil {
+		if _, err := fmt.Fprintf(w, "\n\n"); err != nil {
 			return err
 		}
 	}

--- a/fsm/umlgenerator.go
+++ b/fsm/umlgenerator.go
@@ -178,7 +178,7 @@ func generateFromAnyEventsDeclaration(w io.Writer, anyEvents []anyEventDecl, sta
 
 func generateJustRecordEventsDeclarations(w io.Writer, justRecordEvents map[StateKey][]EventName, stateNameMap reflect.Value, eventNameMap reflect.Value) error {
 	for state, events := range justRecordEvents {
-		if _, err := fmt.Fprintf(w, "\tnote right of %v\n\t\tThese events only record in this state (no handler triggered): \n\n", state); err != nil {
+		if _, err := fmt.Fprintf(w, "\tnote right of %v\n\t\tThe following events only record in this state.\n\n", state); err != nil {
 			return err
 		}
 		for _, event := range events {

--- a/fsm/umlgenerator.go
+++ b/fsm/umlgenerator.go
@@ -81,14 +81,14 @@ func GenerateUML(w io.Writer, syntaxType SyntaxType, parameters Parameters, stat
 		return err
 	}
 
-	if err := generateJustRecordEventsDeclarations(w, justRecordEvents, stateNameMapValue, eventNameMapValue); err != nil {
-		return err
-	}
-
 	for _, event := range events {
 		if err := generateTransitionDeclaration(w, event.start, event.end, event.name, eventNameMapValue); err != nil {
 			return err
 		}
+	}
+
+	if err := generateJustRecordEventsDeclarations(w, justRecordEvents, stateNameMapValue, eventNameMapValue); err != nil {
+		return err
 	}
 
 	for _, state := range parameters.FinalityStates {
@@ -187,7 +187,7 @@ func generateJustRecordEventsDeclarations(w io.Writer, justRecordEvents map[Stat
 				return err
 			}
 		}
-		if _, err := fmt.Fprintf(w, "\tend note\n"); err != nil {
+		if _, err := fmt.Fprintf(w, "\tend note\n\n"); err != nil {
 			return err
 		}
 	}

--- a/fsm/umlgenerator.go
+++ b/fsm/umlgenerator.go
@@ -178,7 +178,7 @@ func generateFromAnyEventsDeclaration(w io.Writer, anyEvents []anyEventDecl, sta
 
 func generateJustRecordEventsDeclarations(w io.Writer, justRecordEvents map[StateKey][]EventName, stateNameMap reflect.Value, eventNameMap reflect.Value) error {
 	for state, events := range justRecordEvents {
-		if _, err := fmt.Fprintf(w, "\n\tnote right of %v : The following events only record in this state.", state); err != nil {
+		if _, err := fmt.Fprintf(w, "\n\tnote left of %v : The following events only record in this state.<br>", state); err != nil {
 			return err
 		}
 		for _, event := range events {

--- a/fsm/umlgenerator.go
+++ b/fsm/umlgenerator.go
@@ -75,9 +75,13 @@ func GenerateUML(w io.Writer, syntaxType SyntaxType, parameters Parameters, stat
 		}
 	}
 
-	events, anyEvents := prepareEvents(parameters.Events, parameters.FinalityStates, states, includeFromAny)
+	events, anyEvents, justRecordEvents := prepareEvents(parameters.Events, parameters.FinalityStates, states, includeFromAny)
 
 	if err := generateFromAnyEventsDeclaration(w, anyEvents, states[0], stateNameMapValue, eventNameMapValue); err != nil {
+		return err
+	}
+
+	if err := generateJustRecordEventsDeclarations(w, justRecordEvents, stateNameMapValue, eventNameMapValue); err != nil {
 		return err
 	}
 
@@ -153,7 +157,11 @@ func generateFromAnyEventsDeclaration(w io.Writer, anyEvents []anyEventDecl, sta
 	}
 	for _, anyEvent := range anyEvents {
 		eventName := eventNameMap.MapIndex(reflect.ValueOf(anyEvent.name))
-		if anyEvent.end == nil {
+		if _, ok := anyEvent.end.(recordEvent); ok {
+			if _, err := fmt.Fprintf(w, "\t\t%s - just records\n", eventName); err != nil {
+				return err
+			}
+		} else if anyEvent.end == nil {
 			if _, err := fmt.Fprintf(w, "\t\t%s - does not transition state\n", eventName); err != nil {
 				return err
 			}
@@ -166,6 +174,24 @@ func generateFromAnyEventsDeclaration(w io.Writer, anyEvents []anyEventDecl, sta
 	}
 	_, err := fmt.Fprintf(w, "\tend note\n")
 	return err
+}
+
+func generateJustRecordEventsDeclarations(w io.Writer, justRecordEvents map[StateKey][]EventName, stateNameMap reflect.Value, eventNameMap reflect.Value) error {
+	for state, events := range justRecordEvents {
+		if _, err := fmt.Fprintf(w, "\tnote right of %v\n\t\tThese events only record in this state (no handler triggered): \n\n", state); err != nil {
+			return err
+		}
+		for _, event := range events {
+			eventName := eventNameMap.MapIndex(reflect.ValueOf(event))
+			if _, err := fmt.Fprintf(w, "\t\t%s\n", eventName); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "\tend note\n"); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func generateStartStateDeclaration(w io.Writer, state StateKey) error {
@@ -206,7 +232,8 @@ func prepareStates(events []EventBuilder, stateCmp func(a, b StateKey) bool) []S
 			if src != nil {
 				states = appendIfMissing(states, src)
 			}
-			if dst != nil {
+			_, justRecord := dst.(recordEvent)
+			if dst != nil && !justRecord {
 				states = appendIfMissing(states, dst)
 			}
 		}
@@ -253,9 +280,10 @@ func getNonFinalityStates(states []StateKey, finalityStates []StateKey) []StateK
 	return nonFinalityStates
 }
 
-func prepareEvents(srcEvents []EventBuilder, finalityStates []StateKey, states []StateKey, includeFromAny bool) ([]eventDecl, []anyEventDecl) {
+func prepareEvents(srcEvents []EventBuilder, finalityStates []StateKey, states []StateKey, includeFromAny bool) ([]eventDecl, []anyEventDecl, map[StateKey][]EventName) {
 	var events []eventDecl
 	var anyEvents []anyEventDecl
+	justRecordEvents := make(map[StateKey][]EventName)
 	nonFinalityStates := getNonFinalityStates(states, finalityStates)
 	for _, evtIface := range srcEvents {
 		evt := evtIface.(eventBuilder)
@@ -263,7 +291,9 @@ func prepareEvents(srcEvents []EventBuilder, finalityStates []StateKey, states [
 		if ok {
 			if includeFromAny {
 				for _, state := range nonFinalityStates {
-					if dst == nil {
+					if _, ok := dst.(recordEvent); ok {
+						justRecordEvents[state] = append(justRecordEvents[state], evt.name)
+					} else if dst == nil {
 						events = append(events, eventDecl{state, state, evt.name})
 					} else {
 						events = append(events, eventDecl{state, dst, evt.name})
@@ -276,7 +306,9 @@ func prepareEvents(srcEvents []EventBuilder, finalityStates []StateKey, states [
 		for _, src := range states {
 			dst, ok := evt.transitionsSoFar[src]
 			if ok {
-				if dst == nil {
+				if _, ok := dst.(recordEvent); ok {
+					justRecordEvents[src] = append(justRecordEvents[src], evt.name)
+				} else if dst == nil {
 					events = append(events, eventDecl{src, src, evt.name})
 				} else {
 					events = append(events, eventDecl{src, dst, evt.name})
@@ -284,5 +316,5 @@ func prepareEvents(srcEvents []EventBuilder, finalityStates []StateKey, states [
 			}
 		}
 	}
-	return events, anyEvents
+	return events, anyEvents, justRecordEvents
 }

--- a/fsm/umlgenerator_test.go
+++ b/fsm/umlgenerator_test.go
@@ -34,11 +34,6 @@ var expectedString = `stateDiagram-v2
 	1 : On entry runs handleA
 	2 : On entry runs handleB
 	[*] --> 0
-	note right of 2
-		The following events only record in this state.
-
-		Just Record!
-	end note
 	0 --> 1 : Start!
 	1 --> 1 : Restart!
 	2 --> 1 : Restart!
@@ -51,6 +46,12 @@ var expectedString = `stateDiagram-v2
 	0 --> 3 : Finish!
 	1 --> 3 : Finish!
 	2 --> 3 : Finish!
+	note right of 2
+		The following events only record in this state.
+
+		Just Record!
+	end note
+
 	3 --> [*]
 `
 
@@ -68,17 +69,18 @@ var expectedStringWithoutAny = `stateDiagram-v2
 		Any! - transitions state to State A
 		Finish! - transitions state to Final State
 	end note
-	note right of 2
-		The following events only record in this state.
-
-		Just Record!
-	end note
 	0 --> 1 : Start!
 	1 --> 1 : Restart!
 	2 --> 1 : Restart!
 	1 --> 2 : B!
 	1 --> 1 : Resume!
 	2 --> 2 : Resume!
+	note right of 2
+		The following events only record in this state.
+
+		Just Record!
+	end note
+
 	3 --> [*]
 `
 

--- a/fsm/umlgenerator_test.go
+++ b/fsm/umlgenerator_test.go
@@ -47,7 +47,7 @@ var expectedString = `stateDiagram-v2
 	1 --> 3 : Finish!
 	2 --> 3 : Finish!
 
-	note right of 2 : The following events only record in this state.<br>Just Record!
+	note left of 2 : The following events only record in this state.<br><br>Just Record!
 
 	3 --> [*]
 `
@@ -73,7 +73,7 @@ var expectedStringWithoutAny = `stateDiagram-v2
 	1 --> 1 : Resume!
 	2 --> 2 : Resume!
 
-	note right of 2 : The following events only record in this state.<br>Just Record!
+	note left of 2 : The following events only record in this state.<br><br>Just Record!
 
 	3 --> [*]
 `

--- a/fsm/umlgenerator_test.go
+++ b/fsm/umlgenerator_test.go
@@ -17,12 +17,13 @@ var stateNameMap = map[uint64]string{
 }
 
 var eventNameMap = map[string]string{
-	"start":   "Start!",
-	"restart": "Restart!",
-	"b":       "B!",
-	"resume":  "Resume!",
-	"any":     "Any!",
-	"finish":  "Finish!",
+	"start":      "Start!",
+	"restart":    "Restart!",
+	"b":          "B!",
+	"resume":     "Resume!",
+	"justrecord": "Just Record!",
+	"any":        "Any!",
+	"finish":     "Finish!",
 }
 
 var expectedString = `stateDiagram-v2
@@ -33,6 +34,11 @@ var expectedString = `stateDiagram-v2
 	1 : On entry runs handleA
 	2 : On entry runs handleB
 	[*] --> 0
+	note right of 2
+		These events only record in this state (no handler triggered): 
+
+		Just Record!
+	end note
 	0 --> 1 : Start!
 	1 --> 1 : Restart!
 	2 --> 1 : Restart!
@@ -61,6 +67,11 @@ var expectedStringWithoutAny = `stateDiagram-v2
 
 		Any! - transitions state to State A
 		Finish! - transitions state to Final State
+	end note
+	note right of 2
+		These events only record in this state (no handler triggered): 
+
+		Just Record!
 	end note
 	0 --> 1 : Start!
 	1 --> 1 : Restart!

--- a/fsm/umlgenerator_test.go
+++ b/fsm/umlgenerator_test.go
@@ -35,7 +35,7 @@ var expectedString = `stateDiagram-v2
 	2 : On entry runs handleB
 	[*] --> 0
 	note right of 2
-		These events only record in this state (no handler triggered): 
+		The following events only record in this state.
 
 		Just Record!
 	end note
@@ -69,7 +69,7 @@ var expectedStringWithoutAny = `stateDiagram-v2
 		Finish! - transitions state to Final State
 	end note
 	note right of 2
-		These events only record in this state (no handler triggered): 
+		The following events only record in this state.
 
 		Just Record!
 	end note

--- a/fsm/umlgenerator_test.go
+++ b/fsm/umlgenerator_test.go
@@ -46,11 +46,8 @@ var expectedString = `stateDiagram-v2
 	0 --> 3 : Finish!
 	1 --> 3 : Finish!
 	2 --> 3 : Finish!
-	note right of 2
-		The following events only record in this state.
 
-		Just Record!
-	end note
+	note right of 2 : The following events only record in this state.<br>Just Record!
 
 	3 --> [*]
 `
@@ -75,11 +72,8 @@ var expectedStringWithoutAny = `stateDiagram-v2
 	1 --> 2 : B!
 	1 --> 1 : Resume!
 	2 --> 2 : Resume!
-	note right of 2
-		The following events only record in this state.
 
-		Just Record!
-	end note
+	note right of 2 : The following events only record in this state.<br>Just Record!
 
 	3 --> [*]
 `

--- a/fsm/verification.go
+++ b/fsm/verification.go
@@ -62,7 +62,8 @@ func VerifyEventParameters(state StateType, stateKeyField StateKeyField, events 
 			return err
 		}
 		for src, dst := range evt.transitionsSoFar {
-			if dst != nil && !reflect.TypeOf(dst).AssignableTo(stateFieldType.Type) {
+			_, justRecord := dst.(recordEvent)
+			if dst != nil && !justRecord && !reflect.TypeOf(dst).AssignableTo(stateFieldType.Type) {
 				return xerrors.Errorf("event `%+v` destination type is not assignable to: %s", name, stateFieldType.Type.Name())
 			}
 			if src != nil && !reflect.TypeOf(src).AssignableTo(stateFieldType.Type) {


### PR DESCRIPTION
# Goals

Sometimes a we need an event that records a state side effect (i.e. changing another value other than the main status) but doesn't trigger a status change OR retriggering the event handler (as opposed to NoChange events which retrigger the event handler)

# Implementation

- add a ToJustRecord() to the EventBuilder
- this makes a destination of `recordEvent` internally for this event type
- unlike destination == nil, recordEvent when bubbled up to the state handler does NOT trigger the state entry func if present
- add code to UML generator to make notes for these events (to avoid cluttering diagrams)