### PR TITLE
Make just record UML predictable

### DIFF
--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -44,6 +44,7 @@ var events = fsm.Events{
 		return nil
 	}),
 	fsm.Event("any").FromAny().To(uint64(1)),
+	fsm.Event("justrecord2").From(uint64(1)).ToJustRecord(),
 	fsm.Event("finish").FromAny().To(uint64(3)),
 }
 

--- a/fsm/umlgenerator.go
+++ b/fsm/umlgenerator.go
@@ -87,7 +87,7 @@ func GenerateUML(w io.Writer, syntaxType SyntaxType, parameters Parameters, stat
 		}
 	}
 
-	if err := generateJustRecordEventsDeclarations(w, justRecordEvents, stateNameMapValue, eventNameMapValue); err != nil {
+	if err := generateJustRecordEventsDeclarations(w, states, justRecordEvents, stateNameMapValue, eventNameMapValue); err != nil {
 		return err
 	}
 
@@ -176,8 +176,12 @@ func generateFromAnyEventsDeclaration(w io.Writer, anyEvents []anyEventDecl, sta
 	return err
 }
 
-func generateJustRecordEventsDeclarations(w io.Writer, justRecordEvents map[StateKey][]EventName, stateNameMap reflect.Value, eventNameMap reflect.Value) error {
-	for state, events := range justRecordEvents {
+func generateJustRecordEventsDeclarations(w io.Writer, states []StateKey, justRecordEvents map[StateKey][]EventName, stateNameMap reflect.Value, eventNameMap reflect.Value) error {
+	for _, state := range states {
+		events, ok := justRecordEvents[state]
+		if !ok {
+			continue
+		}
 		if _, err := fmt.Fprintf(w, "\n\tnote left of %v : The following events only record in this state.<br>", state); err != nil {
 			return err
 		}

--- a/fsm/umlgenerator_test.go
+++ b/fsm/umlgenerator_test.go
@@ -17,13 +17,14 @@ var stateNameMap = map[uint64]string{
 }
 
 var eventNameMap = map[string]string{
-	"start":      "Start!",
-	"restart":    "Restart!",
-	"b":          "B!",
-	"resume":     "Resume!",
-	"justrecord": "Just Record!",
-	"any":        "Any!",
-	"finish":     "Finish!",
+	"start":       "Start!",
+	"restart":     "Restart!",
+	"b":           "B!",
+	"resume":      "Resume!",
+	"justrecord":  "Just Record!",
+	"justrecord2": "Just Also Record",
+	"any":         "Any!",
+	"finish":      "Finish!",
 }
 
 var expectedString = `stateDiagram-v2
@@ -46,6 +47,9 @@ var expectedString = `stateDiagram-v2
 	0 --> 3 : Finish!
 	1 --> 3 : Finish!
 	2 --> 3 : Finish!
+
+	note left of 1 : The following events only record in this state.<br><br>Just Also Record
+
 
 	note left of 2 : The following events only record in this state.<br><br>Just Record!
 
@@ -72,6 +76,9 @@ var expectedStringWithoutAny = `stateDiagram-v2
 	1 --> 2 : B!
 	1 --> 1 : Resume!
 	2 --> 2 : Resume!
+
+	note left of 1 : The following events only record in this state.<br><br>Just Also Record
+
 
 	note left of 2 : The following events only record in this state.<br><br>Just Record!
 


### PR DESCRIPTION
Sorry! Left a map iteration in the ordering of the output for UMLs -- it should always only be arrays, cause map iteration order is non-deterministic.