### PR TITLE
Remove race in log line

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -107,7 +107,7 @@ func (fsm *StateMachine) run() {
 			}
 
 			go func() {
-				defer log.Debugw("leaving critical zone and resetting atomic var to zero", "len(pending)", len(pendingEvents))
+				defer log.Debugw("leaving critical zone and resetting atomic var to zero")
 
 				if nextStep != nil {
 					res := reflect.ValueOf(nextStep).Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(ustate).Elem()})


### PR DESCRIPTION
# Goals

Unfortunately trying to read from pendingEvents in log on 104 is a race with line 55.

# Implementation

Remove len(pendingEvents) from log.