### PR TITLE
Buffer the stageDone channel to prevent hanging goroutine

### DIFF
--- a/group.go
+++ b/group.go
@@ -125,9 +125,8 @@ func (s *StateGroup) loadOrCreate(name interface{}, userState interface{}) (*Sta
 		st:        s.sts.Get(name),
 		stateType: s.stateType,
 
-		stageDone: make(chan struct{}),
-		closing:   make(chan struct{}),
-		closed:    make(chan struct{}),
+		closing: make(chan struct{}),
+		closed:  make(chan struct{}),
 	}
 
 	go res.run()


### PR DESCRIPTION
If the statemachine is closed and there is no more reader for the stageDone channel, then the `run` goroutine can hang waiting to write to stageDone.  Buffering the channel prevents this by allowing the chanable to writable even if the reader is gone.

The stageDone channel is now local to the `run` function as it was never used outside of it.