### PR TITLE
Option to apply all events before state entry functions

### DIFF
--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -12,14 +12,15 @@ import (
 var log = logging.Logger("fsm")
 
 type fsmHandler struct {
-	stateType       reflect.Type
-	stateKeyField   StateKeyField
-	notifier        Notifier
-	notifications   chan notification
-	eventProcessor  EventProcessor
-	stateEntryFuncs StateEntryFuncs
-	environment     Environment
-	finalityStates  map[StateKey]struct{}
+	stateType                        reflect.Type
+	stateKeyField                    StateKeyField
+	notifier                         Notifier
+	notifications                    chan notification
+	eventProcessor                   EventProcessor
+	stateEntryFuncs                  StateEntryFuncs
+	environment                      Environment
+	finalityStates                   map[StateKey]struct{}
+	consumeAllEventsBeforeEntryFuncs bool
 }
 
 const NotificationQueueSize = 128
@@ -43,13 +44,14 @@ func NewFSMHandler(parameters Parameters) (statemachine.StateHandler, error) {
 		return nil, err
 	}
 	d := fsmHandler{
-		environment:     parameters.Environment,
-		stateType:       stateType,
-		stateKeyField:   parameters.StateKeyField,
-		eventProcessor:  eventProcessor,
-		stateEntryFuncs: make(StateEntryFuncs),
-		notifier:        parameters.Notifier,
-		finalityStates:  make(map[StateKey]struct{}),
+		environment:                      parameters.Environment,
+		stateType:                        stateType,
+		stateKeyField:                    parameters.StateKeyField,
+		eventProcessor:                   eventProcessor,
+		stateEntryFuncs:                  make(StateEntryFuncs),
+		notifier:                         parameters.Notifier,
+		finalityStates:                   make(map[StateKey]struct{}),
+		consumeAllEventsBeforeEntryFuncs: parameters.Options.ConsumeAllEventsBeforeEntryFuncs,
 	}
 
 	// type check state handlers
@@ -79,39 +81,68 @@ func NewFSMHandler(parameters Parameters) (statemachine.StateHandler, error) {
 // if specified
 func (d fsmHandler) Plan(events []statemachine.Event, user interface{}) (interface{}, uint64, error) {
 	userValue := reflect.ValueOf(user)
+	// if we reach a finality state, we do not process events
 	if d.reachedFinalityState(userValue.Elem().Interface()) {
 		d.eventProcessor.ClearEvents(events, statemachine.ErrTerminated)
 		return nil, uint64(len(events)), statemachine.ErrTerminated
 	}
-	eventName, err := d.eventProcessor.Apply(events[0], user)
-	if _, ok := eventName.(nilEvent); ok {
-		return nil, 1, nil
+	// in normal mode, we consume exactly one event per call to Plan,
+	// meaning state entry funcs are immediately processed
+	processedEventTarget := 1
+	// in consume all events mode, we attempt to process every event in each call to Plan,
+	// meaning state entry funcs are processed only when all waiting events are consumed
+	if d.consumeAllEventsBeforeEntryFuncs {
+		processedEventTarget = len(events)
 	}
-	_, skipHandler := err.(ErrSkipHandler)
-	if err != nil && !skipHandler {
-		log.Errorf("Executing event planner failed for %s: %+v", d.stateType.Name(), err)
-		return nil, 1, nil
-	}
-	currentState := userValue.Elem().FieldByName(string(d.stateKeyField)).Interface()
-	if d.notifier != nil {
-		currentTime := time.Now()
-		d.notifications <- notification{eventName, userValue.Elem().Interface()}
-		elapsed := time.Since(currentTime)
-		if elapsed > maxExpectedEventProcessingTime {
-			log.Warnw("notification queued", "fsmType", d.stateType.Name(), "eventName", eventName, "queueTime", elapsed)
-		} else {
-			log.Debugw("notification queued", "fsmType", d.stateType.Name(), "eventName", eventName, "queueTime", elapsed)
+	var runHandler bool
+	var currentState interface{}
+	// for each event up to the target
+	for i := 0; i < processedEventTarget; i++ {
+		// process the event
+		eventName, err := d.eventProcessor.Apply(events[i], user)
+		// internally the fsm creates private "nil events" to support
+		// synchronization
+		if _, ok := eventName.(nilEvent); ok {
+			continue
+		}
+		_, skipHandler := err.(ErrSkipHandler)
+		// terminate if there is a non-skip error
+		if err != nil && !skipHandler {
+			log.Errorf("Executing event planner failed for %s: %+v", d.stateType.Name(), err)
+			return nil, uint64(i + 1), nil
+		}
+		// when processing multiple events, we run the handler unless all events
+		// return ErrSkipHandler (i.e. ToJustRecord)
+		if !skipHandler {
+			runHandler = true
+		}
+		// read the state
+		currentState = userValue.Elem().FieldByName(string(d.stateKeyField)).Interface()
+
+		// dispatch notification
+		if d.notifier != nil {
+			currentTime := time.Now()
+			d.notifications <- notification{eventName, userValue.Elem().Interface()}
+			elapsed := time.Since(currentTime)
+			if elapsed > maxExpectedEventProcessingTime {
+				log.Warnw("notification queued", "fsmType", d.stateType.Name(), "eventName", eventName, "queueTime", elapsed)
+			} else {
+				log.Debugw("notification queued", "fsmType", d.stateType.Name(), "eventName", eventName, "queueTime", elapsed)
+			}
+		}
+		// if we're now in finality, return
+		_, final := d.finalityStates[currentState]
+		if final {
+			d.eventProcessor.ClearEvents(events[i+1:], statemachine.ErrTerminated)
+			return nil, uint64(len(events)), statemachine.ErrTerminated
 		}
 	}
-	_, final := d.finalityStates[currentState]
-	if final {
-		d.eventProcessor.ClearEvents(events[1:], statemachine.ErrTerminated)
-		return nil, uint64(len(events)), statemachine.ErrTerminated
+
+	// run the state entry func as needed
+	if !runHandler {
+		return d.handler(nil), uint64(processedEventTarget), nil
 	}
-	if skipHandler {
-		return d.handler(nil), 1, nil
-	}
-	return d.handler(d.stateEntryFuncs[currentState]), 1, nil
+	return d.handler(d.stateEntryFuncs[currentState]), uint64(processedEventTarget), nil
 }
 
 func (d fsmHandler) reachedFinalityState(user interface{}) bool {

--- a/fsm/types.go
+++ b/fsm/types.go
@@ -139,6 +139,15 @@ type Group interface {
 	Stop(ctx context.Context) error
 }
 
+// Options change how the state machine operates
+type Options struct {
+	// ConsumeAllEventsBeforeEntryFuncs causes the state machine to consume every waiting FSM event before
+	// the next StateEntryFunc is called. The normal operation is to only consume one event then call
+	// the StateEntryFunc. Sometimes, this can cause unexpected behavior if multiple FSM events are queued,
+	// causing multiple StateEntryFunc's to get called in unpredictable succession
+	ConsumeAllEventsBeforeEntryFuncs bool
+}
+
 // Parameters are the parameters that define a finite state machine
 type Parameters struct {
 	// required
@@ -171,4 +180,7 @@ type Parameters struct {
 	// FinalityStates are states in which the statemachine will shut down,
 	// stop calling handlers and stop processing events
 	FinalityStates []StateKey
+
+	// Options
+	Options Options
 }


### PR DESCRIPTION
# Goals

This PR adds a long requested feature to go-statemachine -- to process multiple events at once before we apply the next StateEntryFunc. 

# Implementation

Adds an optional parameter to process multiple state machine updates before applying a state entry func. This has been an ongoing issue where StateEntryFuncs get called after already being outdated by additional state machine events.

It's added as an optional parameter as this is a potentially far reaching change and it's worth rolling it out gradually.
