### PR TITLE
ci: explicitly switch macos build to silicon and upgrade xcode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,8 @@ jobs:
   build-macos:
     description: build with Darwin
     macos:
-      xcode: "10.0.0"
+      xcode: "15.0.0"
+    resource_class: macos.x86.medium.gen2
     working_directory: ~/go/src/github.com/filecoin-project/go-storage-miner
     steps:
       - prepare:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
       - when:
           condition: << parameters.linux >>
           steps:
-            - run: sudo apt-get update
+            - run: sudo apt-get update --allow-releaseinfo-change
             - run: sudo apt-get install ocl-icd-opencl-dev
       - run: git submodule sync
       - run: git submodule update --init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 orbs:
+  golang: circleci/go@1.7.3
   go: gotest/tools@0.0.9
 
 executors:
@@ -90,11 +91,8 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - run:
-          name: Install go
-          command: |
-            curl -O https://dl.google.com/go/go1.13.4.darwin-amd64.pkg && \
-            sudo installer -pkg go1.13.4.darwin-amd64.pkg -target /
+      - golang/install:
+          version: "1.13.4"
       - run:
           name: Install pkg-config
           command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
       - run:
           name: Install jq
           command: |
-            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64
+            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 --output jq-osx-amd64
             chmod +x jq-osx-amd64
             sudo mv jq-osx-amd64 /usr/local/bin/jq
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,9 @@ jobs:
       - run:
           name: Install jq
           command: |
-            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 --output /usr/local/bin/jq
-            chmod +x /usr/local/bin/jq
+            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64
+            chmod +x jq-osx-amd64
+            sudo mv jq-osx-amd64 /usr/local/bin/jq
       - restore_cache:
           name: restore go mod and cargo cache
           key: v1-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/go-storage-miner/go.sum" }}


### PR DESCRIPTION
CircleCI is removing support for Apple Intel executors on Oct 2 - see https://discuss.circleci.com/t/macos-resource-deprecation-update/46891. After that date only Apple Silicon executors will be available. This PR ensures the macos builds are executed on Apple Silicon executors only.